### PR TITLE
QuerySelectField: Add support for blank choice when using groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "WTForms>=3.1",
+    "WTForms>=3.1.2",
     "SQLAlchemy>=1.4",
 ]
 dynamic = ["version"]

--- a/src/wtforms_sqlalchemy/fields.py
+++ b/src/wtforms_sqlalchemy/fields.py
@@ -147,9 +147,12 @@ class QuerySelectField(SelectFieldBase):
             self._object_list = list((str(get_pk(obj)), obj) for obj in query)
         return self._object_list
 
+    def _get_blank_choice(self):
+        return (self.blank_value, self.blank_text, self.data is None, {})
+
     def iter_choices(self):
         if self.allow_blank:
-            yield (self.blank_value, self.blank_text, self.data is None, {})
+            yield self._get_blank_choice()
 
         for pk, obj in self._get_object_list():
             yield (pk, self.get_label(obj), obj == self.data, self.get_render_kw(obj))
@@ -159,6 +162,9 @@ class QuerySelectField(SelectFieldBase):
 
     def iter_groups(self):
         if self.has_groups():
+            if self.allow_blank:
+                yield (None, [self._get_blank_choice()])
+
             groups = defaultdict(list)
             for pk, obj in self._get_object_list():
                 groups[self.get_group(obj)].append((pk, obj))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -217,6 +217,7 @@ class QuerySelectFieldTest(TestBase):
         self.assertEqual(
             form.d(),
             [
+                (None, [("", "", True, {})]),
                 (
                     "a",
                     [("hello1", "apple", False, {}), ("hello3", "apricot", False, {})],
@@ -260,6 +261,7 @@ class QuerySelectFieldTest(TestBase):
         self.assertEqual(
             form.d(),
             [
+                (None, [("", "", False, {})]),
                 (
                     "a",
                     [("hello1", "apple", False, {}), ("hello3", "apricot", True, {})],

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -40,6 +40,20 @@ class LazySelect:
         )
 
 
+class LazyGroupSelect:
+    def __call__(self, field, **kwargs):
+        return list(
+            (
+                group,
+                list(
+                    (val, str(label), selected, render_kw)
+                    for val, label, selected, render_kw in choices
+                ),
+            )
+            for group, choices in field.iter_groups()
+        )
+
+
 class Base:
     def __init__(self, **kwargs):
         for k, v in iter(kwargs.items()):
@@ -83,7 +97,7 @@ class TestBase(TestCase):
         mapper_registry.metadata.create_all(bind=engine)
 
     def _fill(self, sess):
-        for i, n in [(1, "apple"), (2, "banana")]:
+        for i, n in [(1, "apple"), (2, "banana"), (3, "apricot")]:
             s = self.Test(id=i, name=n)
             p = self.PKTest(foobar=f"hello{i}", baz=n)
             sess.add(s)
@@ -117,7 +131,12 @@ class QuerySelectFieldTest(TestBase):
         self.assertTrue(form.a.data is not None)
         self.assertEqual(form.a.data.id, 1)
         self.assertEqual(
-            form.a(), [("1", "apple", True, {}), ("2", "banana", False, {})]
+            form.a(),
+            [
+                ("1", "apple", True, {}),
+                ("2", "banana", False, {}),
+                ("3", "apricot", False, {}),
+            ],
         )
         self.assertTrue(form.validate())
 
@@ -155,11 +174,24 @@ class QuerySelectFieldTest(TestBase):
                 query_factory=lambda: sess.query(self.PKTest),
                 widget=LazySelect(),
             )
+            d = QuerySelectField(
+                allow_blank=True,
+                blank_text="",
+                blank_value="",
+                query_factory=lambda: sess.query(self.PKTest),
+                get_group=lambda x: x.baz[0],
+                widget=LazyGroupSelect(),
+            )
 
         form = F()
         self.assertEqual(form.a.data, None)
         self.assertEqual(
-            form.a(), [("1", "apple", False, {}), ("2", "banana", False, {})]
+            form.a(),
+            [
+                ("1", "apple", False, {}),
+                ("2", "banana", False, {}),
+                ("3", "apricot", False, {}),
+            ],
         )
         self.assertEqual(form.b.data, None)
         self.assertEqual(
@@ -168,6 +200,7 @@ class QuerySelectFieldTest(TestBase):
                 ("__None", "", True, {}),
                 ("hello1", "apple", False, {}),
                 ("hello2", "banana", False, {}),
+                ("hello3", "apricot", False, {}),
             ],
         )
         self.assertEqual(form.c.data, None)
@@ -177,14 +210,31 @@ class QuerySelectFieldTest(TestBase):
                 ("", "", True, {}),
                 ("hello1", "apple", False, {}),
                 ("hello2", "banana", False, {}),
+                ("hello3", "apricot", False, {}),
+            ],
+        )
+        self.assertEqual(form.d.data, None)
+        self.assertEqual(
+            form.d(),
+            [
+                (
+                    "a",
+                    [("hello1", "apple", False, {}), ("hello3", "apricot", False, {})],
+                ),
+                ("b", [("hello2", "banana", False, {})]),
             ],
         )
         self.assertFalse(form.validate())
 
-        form = F(DummyPostData(a=["1"], b=["hello2"], c=[""]))
+        form = F(DummyPostData(a=["1"], b=["hello2"], c=[""], d=["hello3"]))
         self.assertEqual(form.a.data.id, 1)
         self.assertEqual(
-            form.a(), [("1", "apple", True, {}), ("2", "banana", False, {})]
+            form.a(),
+            [
+                ("1", "apple", True, {}),
+                ("2", "banana", False, {}),
+                ("3", "apricot", False, {}),
+            ],
         )
         self.assertEqual(form.b.data.baz, "banana")
         self.assertEqual(
@@ -193,6 +243,7 @@ class QuerySelectFieldTest(TestBase):
                 ("__None", "", False, {}),
                 ("hello1", "apple", False, {}),
                 ("hello2", "banana", True, {}),
+                ("hello3", "apricot", False, {}),
             ],
         )
         self.assertEqual(form.c.data, None)
@@ -202,16 +253,33 @@ class QuerySelectFieldTest(TestBase):
                 ("", "", True, {}),
                 ("hello1", "apple", False, {}),
                 ("hello2", "banana", False, {}),
+                ("hello3", "apricot", False, {}),
+            ],
+        )
+        self.assertEqual(form.d.data.baz, "apricot")
+        self.assertEqual(
+            form.d(),
+            [
+                (
+                    "a",
+                    [("hello1", "apple", False, {}), ("hello3", "apricot", True, {})],
+                ),
+                ("b", [("hello2", "banana", False, {})]),
             ],
         )
         self.assertTrue(form.validate())
 
         # Make sure the query is cached
-        sess.add(self.Test(id=3, name="meh"))
+        sess.add(self.Test(id=4, name="meh"))
         sess.flush()
         sess.commit()
         self.assertEqual(
-            form.a(), [("1", "apple", True, {}), ("2", "banana", False, {})]
+            form.a(),
+            [
+                ("1", "apple", True, {}),
+                ("2", "banana", False, {}),
+                ("3", "apricot", False, {}),
+            ],
         )
         form.a._object_list = None
         self.assertEqual(
@@ -219,7 +287,8 @@ class QuerySelectFieldTest(TestBase):
             [
                 ("1", "apple", True, {}),
                 ("2", "banana", False, {}),
-                ("3", "meh", False, {}),
+                ("3", "apricot", False, {}),
+                ("4", "meh", False, {}),
             ],
         )
 
@@ -264,7 +333,12 @@ class QuerySelectMultipleFieldTest(TestBase):
         form.a.query = self.sess.query(self.Test)
         self.assertEqual([1], [v.id for v in form.a.data])
         self.assertEqual(
-            form.a(), [("1", "apple", True, {}), ("2", "banana", False, {})]
+            form.a(),
+            [
+                ("1", "apple", True, {}),
+                ("2", "banana", False, {}),
+                ("3", "apricot", False, {}),
+            ],
         )
         self.assertTrue(form.validate())
 
@@ -273,11 +347,16 @@ class QuerySelectMultipleFieldTest(TestBase):
         form.a.query = self.sess.query(self.Test)
         self.assertEqual([1, 2], [v.id for v in form.a.data])
         self.assertEqual(
-            form.a(), [("1", "apple", True, {}), ("2", "banana", True, {})]
+            form.a(),
+            [
+                ("1", "apple", True, {}),
+                ("2", "banana", True, {}),
+                ("3", "apricot", False, {}),
+            ],
         )
         self.assertTrue(form.validate())
 
-        form = self.F(DummyPostData(a=["1", "3"]))
+        form = self.F(DummyPostData(a=["1", "4"]))
         form.a.query = self.sess.query(self.Test)
         self.assertEqual([x.id for x in form.a.data], [1])
         self.assertFalse(form.validate())
@@ -296,7 +375,12 @@ class QuerySelectMultipleFieldTest(TestBase):
         form = F()
         self.assertEqual([v.id for v in form.a.data], [2])
         self.assertEqual(
-            form.a(), [("1", "apple", False, {}), ("2", "banana", True, {})]
+            form.a(),
+            [
+                ("1", "apple", False, {}),
+                ("2", "banana", True, {}),
+                ("3", "apricot", False, {}),
+            ],
         )
         self.assertTrue(form.validate())
 


### PR DESCRIPTION
This PR adds support for a blank choice  inconjunction with grouped data for the `QuerySelectField`.

Note that this PR depends on the **unreleased** and **unmerged** PR https://github.com/pallets-eco/wtforms/pull/870.